### PR TITLE
Allow non-canonical option names.

### DIFF
--- a/moped/src/main/scala/moped/cli/TabCompletionContext.scala
+++ b/moped/src/main/scala/moped/cli/TabCompletionContext.scala
@@ -1,6 +1,6 @@
 package moped.cli
 
-import moped.internal.console.InlinedFlag
+import moped.internal.console.ValidOption
 import moped.macros.ParameterShape
 
 final case class TabCompletionContext(
@@ -9,6 +9,6 @@ final case class TabCompletionContext(
     last: String,
     secondLast: Option[String],
     setting: Option[ParameterShape],
-    allSettings: Map[String, List[InlinedFlag]],
+    allSettings: Map[String, List[ValidOption]],
     app: Application
 )

--- a/moped/src/main/scala/moped/commands/RunCompletionsCommand.scala
+++ b/moped/src/main/scala/moped/commands/RunCompletionsCommand.scala
@@ -141,7 +141,9 @@ class RunCompletionsCommand(app: Application) extends Command {
       .inlinedSettings(subcommand)
       .filter { case (_, params) =>
         params.exists { param =>
-          !param.shape.isHidden || !param.shape.isPositionalArgument
+          param.isCanonical && {
+            !param.shape.isHidden || !param.shape.isPositionalArgument
+          }
         }
       }
     val secondLast = (head :: tail).takeRight(2) match {

--- a/moped/src/main/scala/moped/internal/console/ValidOption.scala
+++ b/moped/src/main/scala/moped/internal/console/ValidOption.scala
@@ -1,0 +1,31 @@
+package moped.internal.console
+
+import moped.macros.ParameterShape
+
+/**
+ * Represents a valid command-line option.
+ *
+ * @param name
+ *   the syntax that is accepted from the command-line. Normally the same as
+ *   `path.mkString(".")` for canonicalized options, but non-canonical options
+ *   may drop a few prefixes from the path.
+ * @param path
+ *   the nested keys to insert to update this option. For example, the path
+ *   List("a", "b", "c") becomes the JSON object {"a": {"b": {"c":
+ *   PARSED_OPTION}}}.
+ * @param isCanonical
+ *   a valid option can have many different names, is this the canonical name of
+ *   this option? For example
+ * @param shape
+ */
+final case class ValidOption(
+    name: String,
+    path: List[String],
+    isCanonical: Boolean,
+    shape: ParameterShape
+)
+
+object ValidOption {
+  def apply(param: ParameterShape): ValidOption =
+    ValidOption(param.name, param.name :: Nil, isCanonical = true, param)
+}

--- a/tests/src/test/scala/tests/ApplicationSuite.scala
+++ b/tests/src/test/scala/tests/ApplicationSuite.scala
@@ -47,8 +47,20 @@ class ApplicationSuite extends BaseSuite {
   )
 
   checkOutput(
+    "cwd",
+    List("example-cwd", "--cwd", "custom-working-directory"),
+    "cwd=custom-working-directory"
+  )
+
+  checkOutput(
     "app.cwd",
     List("example-cwd", "--app.cwd", "custom-working-directory"),
+    "cwd=custom-working-directory"
+  )
+
+  checkOutput(
+    "shared.app.cwd",
+    List("example-cwd", "--shared.app.cwd", "custom-working-directory"),
     "cwd=custom-working-directory"
   )
 }

--- a/tests/src/test/scala/tests/ExampleCwdCommand.scala
+++ b/tests/src/test/scala/tests/ExampleCwdCommand.scala
@@ -7,7 +7,10 @@ import moped.cli.Command
 import moped.cli.CommandParser
 import moped.json.JsonCodec
 
-case class SharedCwdOptions(app: Application = Application.default)
+case class SharedCwdOptions(
+    @Inline
+    app: Application = Application.default
+)
 
 object SharedCwdOptions {
   implicit val codec: JsonCodec[SharedCwdOptions] = moped

--- a/tests/src/test/scala/tests/RunCompletionsCommandSuite.scala
+++ b/tests/src/test/scala/tests/RunCompletionsCommandSuite.scala
@@ -79,4 +79,10 @@ class RunCompletionsCommandSuite extends BaseSuite {
   checkCompletions("help-subcommand-repeat", List("help", "echo", ""), List())
 
   checkCompletions("path", List("help", "echo", ""), List())
+
+  checkCompletions(
+    "inline-nested",
+    List("example-cwd", "-"),
+    List("--cwd", "--help")
+  )
 }


### PR DESCRIPTION
Previously, inlined options could not be configured as non-inline.
Now, an option can be configured via both inline names and non-inline
names.