### PR TITLE
Cross to Scala 2.13 and bump various dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: olafurpg/setup-scala@v10
         with:
           java-version: "adopt@1.${{ matrix.java }}"
-      - run: sbt coverage test docs/mdoc coverageReport
+      - run: sbt coverage +test docs/mdoc coverageReport
         shell: bash
       - run: bash <(curl -s https://codecov.io/bash)
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: olafurpg/setup-scala@v10
-      - uses: olafurpg/setup-gpg@v2
+      - uses: olafurpg/setup-gpg@v3
       - run: git fetch --tags || true
       - name: Publish ${{ github.ref }}
         run: sbt ci-release

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
-def scala212 = "2.12.11"
+def scala212 = "2.12.12"
+def scala213 = "2.13.3"
 def isCI = "true".equalsIgnoreCase(System.getenv("CI"))
 inThisBuild(
   List(
@@ -16,10 +17,11 @@ inThisBuild(
         )
       ),
     useSuperShell := false,
-    scalaVersion := scala212,
+    scalaVersion := scala213,
     scalafixDependencies +=
-      "com.github.liancheng" %% "organize-imports" % "0.4.0",
+      "com.github.liancheng" %% "organize-imports" % "0.4.4",
     scalafixCaching := true,
+    scalafixScalaBinaryVersion := scalaBinaryVersion.value,
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision,
     publishArtifact.in(Compile, packageDoc) := isCI,
@@ -55,22 +57,24 @@ lazy val moped = project.settings(
   libraryDependencies ++=
     List(
       "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-      "dev.dirs" % "directories" % "20",
+      "dev.dirs" % "directories" % "21",
       "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.2",
       "io.github.alexarchambault" %% "data-class" % "0.2.5",
       "com.lihaoyi" %% "os-lib" % "0.7.1",
-      "com.lihaoyi" %% "ujson" % "1.2.0",
-      "com.lihaoyi" %% "pprint" % "0.5.9",
-      "com.lihaoyi" %% "fansi" % "0.2.7",
-      "org.typelevel" %% "paiges-core" % "0.3.1"
-    )
+      "com.lihaoyi" %% "ujson" % "1.2.2",
+      "com.lihaoyi" %% "pprint" % "0.6.0",
+      "com.lihaoyi" %% "fansi" % "0.2.9",
+      "org.typelevel" %% "paiges-core" % "0.3.2"
+    ),
+  crossScalaVersions := List(scala212, scala213)
 )
 
 lazy val hocon = project
   .in(file("moped-hocon"))
   .settings(
     moduleName := "moped-hocon",
-    libraryDependencies ++= List("org.ekrich" %% "sconfig" % "1.3.1")
+    libraryDependencies ++= List("org.ekrich" %% "sconfig" % "1.3.4"),
+    crossScalaVersions := List(scala212, scala213)
   )
   .dependsOn(moped)
 
@@ -78,7 +82,8 @@ lazy val yaml = project
   .in(file("moped-yaml"))
   .settings(
     moduleName := "moped-yaml",
-    libraryDependencies ++= List("org.yaml" % "snakeyaml" % "1.26")
+    libraryDependencies ++= List("org.yaml" % "snakeyaml" % "1.26"),
+    crossScalaVersions := List(scala212, scala213)
   )
   .dependsOn(moped)
 
@@ -86,7 +91,8 @@ lazy val toml = project
   .in(file("moped-toml"))
   .settings(
     moduleName := "moped-toml",
-    libraryDependencies ++= List("tech.sparse" %% "toml-scala" % "0.2.2")
+    libraryDependencies ++= List("tech.sparse" %% "toml-scala" % "0.2.2"),
+    crossScalaVersions := List(scala212, scala213)
   )
   .dependsOn(moped)
 
@@ -94,7 +100,8 @@ lazy val dhall = project
   .in(file("moped-dhall"))
   .settings(
     moduleName := "moped-dhall",
-    libraryDependencies ++= List("org.dhallj" %% "dhall-scala" % "0.5.0-M1")
+    libraryDependencies ++= List("org.dhallj" %% "dhall-scala" % "0.7.0-M1"),
+    crossScalaVersions := List(scala212, scala213)
   )
   .dependsOn(moped)
 
@@ -102,7 +109,8 @@ lazy val jsonnet = project
   .in(file("moped-jsonnet"))
   .settings(
     moduleName := "moped-jsonnet",
-    libraryDependencies ++= List("com.lihaoyi" %% "sjsonnet" % "0.2.6")
+    libraryDependencies ++= List("com.lihaoyi" %% "sjsonnet" % "0.2.6"),
+    crossScalaVersions := List(scala212, scala213)
   )
   .dependsOn(moped)
 
@@ -110,7 +118,8 @@ lazy val testkit = project
   .in(file("moped-testkit"))
   .settings(
     moduleName := "moped-testkit",
-    libraryDependencies ++= List("org.scalameta" %% "munit" % "0.7.10")
+    libraryDependencies ++= List("org.scalameta" %% "munit" % "0.7.18"),
+    crossScalaVersions := List(scala212, scala213)
   )
   .dependsOn(moped)
 
@@ -145,7 +154,6 @@ lazy val plugin = project
   .settings(
     sbtPlugin := true,
     moduleName := "sbt-moped",
-    crossScalaVersions := List(scala212),
     buildInfoPackage := "sbtmoped",
     buildInfoKeys := Seq[BuildInfoKey](version)
   )

--- a/moped/src/main/scala/moped/json/DecodingContext.scala
+++ b/moped/src/main/scala/moped/json/DecodingContext.scala
@@ -29,7 +29,7 @@ final class DecodingContext private (
     new DecodingContext(json, cursor, app, fatalUnknownFields)
   }
   override def toString(): String =
-    s"DecodingContext(json=${pprint.PPrinter.BlackWhite.tokenize(json).mkString}, cursor=$cursor)",
+    s"DecodingContext(json=${pprint.PPrinter.BlackWhite.tokenize(json).mkString}, cursor=$cursor)"
 }
 
 object DecodingContext {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.12
+sbt.version=1.4.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")
 addSbtPlugin("org.scalameta" % "sbt-native-image" % "0.2.2")
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.10")
-addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.3")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.19")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.12")
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.4")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.23")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 


### PR DESCRIPTION
This pr cross publishes to 2.13, updates various dependencies, sbt-plugins, sbt version, and some of the actions versions. Instead of having the default Scala version set to 2.12 I did switch this to 2.13 and then added in cross to 2.12. If that's an issue an you still want to default to 2.12, let me know and I can swap it back. I hope I got everything.