### PR TITLE
Hide error when there's no TTY in Tput

### DIFF
--- a/moped/src/main/scala/moped/reporters/Tput.scala
+++ b/moped/src/main/scala/moped/reporters/Tput.scala
@@ -3,6 +3,7 @@ package moped.reporters
 import java.nio.file.Files
 import java.nio.file.Paths
 
+import scala.sys.process.ProcessLogger
 import scala.util.Try
 import scala.util.control.NonFatal
 
@@ -23,6 +24,12 @@ object Tput {
             else
               "tput"
           try {
+            val nullLog =
+              new ProcessLogger {
+                override def out(s: => String): Unit = ()
+                override def err(s: => String): Unit = ()
+                override def buffer[T](f: => T): T = f
+              }
             val output =
               scala
                 .sys
@@ -34,7 +41,7 @@ object Tput {
                     s"""echo "cols\nlines" | $tputPath -S 2> /dev/tty"""
                   )
                 )
-                .!!
+                .!!(nullLog)
                 .linesIterator
                 .map(_.toInt)
                 .toList


### PR DESCRIPTION
Previously, the following error message would be printed repeatedly when
trying to get the window's size and there's no TTY available:

    sh: line 1: /dev/tty: No such device or address

This commit ignores the error message printed by the shell so that it
doesn't pollute the terminal. This is the same solution that was used by
Coursier, for instance: https://github.com/coursier/coursier/pull/201