### PR TITLE
Automatically strip out ANSI colors when `NO_COLOR=true`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,14 +24,13 @@ inThisBuild(
     scalafixScalaBinaryVersion := scalaBinaryVersion.value,
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision,
-    publishArtifact.in(Compile, packageDoc) := isCI,
-    publishArtifact.in(packageDoc) := isCI,
+    semanticdbOptions += s"-P:semanticdb:sourceroot:${baseDirectory.value}",
     scalacOptions ++= List("-Ywarn-unused:imports", "-Yrangepos")
   )
 )
 
 crossScalaVersions := Nil
-skip.in(publish) := true
+(publish / skip) := true
 lazy val isAtLeastScala213 = Def.setting {
   import Ordering.Implicits._
   CrossVersion.partialVersion(scalaVersion.value).exists(_ >= (2, 13))
@@ -125,14 +124,14 @@ lazy val testkit = project
 
 lazy val tests = project
   .settings(
-    skip.in(publish) := true,
+    (publish / skip) := true,
     testFrameworks := List(new TestFramework("munit.Framework")),
     buildInfoPackage := "tests",
     buildInfoKeys :=
       Seq[BuildInfoKey](
-        "expectDirectory" -> sourceDirectory.in(Test).value./("expect")
+        "expectDirectory" -> (Test / sourceDirectory).value./("expect")
       ),
-    mainClass.in(Compile) := Some("tests.EchoCommand"),
+    (Compile / mainClass) := Some("tests.EchoCommand"),
     nativeImageOptions ++=
       List(
         "--initialize-at-build-time",
@@ -164,7 +163,7 @@ lazy val docs = project
   .settings(
     moduleName := "moped-docs",
     fork := isCI,
-    skip in publish := true,
+    (publish / skip) := true,
     libraryDependencies ++=
       List("com.lihaoyi" %% "scalatags" % scalatagsVersion.value),
     mdocVariables :=
@@ -174,9 +173,9 @@ lazy val docs = project
         "SCALA_VERSION" -> scalaVersion.value
       ),
     mdocOut :=
-      baseDirectory.in(ThisBuild).value / "website" / "target" / "docs",
+      (ThisBuild / baseDirectory).value / "website" / "target" / "docs",
     mdocExtraArguments := {
-      val cwd = baseDirectory.in(ThisBuild).value
+      val cwd = (ThisBuild / baseDirectory).value
       List(
         "--no-link-hygiene",
         "--in",

--- a/moped-testkit/src/main/scala/moped/testkit/MopedSuite.scala
+++ b/moped-testkit/src/main/scala/moped/testkit/MopedSuite.scala
@@ -81,8 +81,11 @@ abstract class MopedSuite(applicationToTest: Application) extends FunSuite {
     def reset(): Unit = {
       out.reset()
     }
+    def capturedRawOutput: String = {
+      out.toString(StandardCharsets.UTF_8.name())
+    }
     def capturedOutput: String = {
-      AnsiColors.filterAnsi(out.toString(StandardCharsets.UTF_8.name()))
+      AnsiColors.filterAnsi(capturedRawOutput)
     }
     override def beforeEach(context: BeforeEach): Unit = {
       Files.createDirectories(workingDirectory)
@@ -127,7 +130,14 @@ abstract class MopedSuite(applicationToTest: Application) extends FunSuite {
   }
 
   def runSuccessfully(arguments: List[String]): Unit = {
-    val exit = app().run(arguments)
+    runSuccessfully(arguments, app())
+  }
+
+  def runSuccessfully(
+      arguments: List[String],
+      application: Application
+  ): Unit = {
+    val exit = application.run(arguments)
     assertEquals(exit, 0, clues(app.capturedOutput))
   }
 

--- a/moped/src/main/scala/moped/internal/reporters/AnsiStateMachine.scala
+++ b/moped/src/main/scala/moped/internal/reporters/AnsiStateMachine.scala
@@ -1,0 +1,59 @@
+// This file contains adapted source code from tut, see NOTICE.md for LICENSE.
+// Original source: https://github.com/tpolecat/tut/blob/e692c74afe7cb9f144f464b97f100c11367c7dfa/modules/core/src/main/scala/tut/AnsiFilterStream.scala
+package moped.internal.reporters
+
+/**
+ * A state machine for filtering out ANSI escape codes from a character stream.
+ *
+ * In addition to stripping out ANSI escape codes, we also strip out carriage
+ * return \r characters from Windows-style "\r\n" line breaks.
+ */
+case class AnsiStateMachine(apply: Int => AnsiStateMachine)
+object AnsiStateMachine {
+  // Helpful docs on ANSI escape sequences: http://ascii-table.com/ansi-escape-sequences.php
+  val Start: AnsiStateMachine = AnsiStateMachine {
+    case 27 =>
+      AnsiEscape
+    case '\r' =>
+      CarriageReturn
+    case _ =>
+      Print
+  }
+
+  val CarriageReturn: AnsiStateMachine = AnsiStateMachine {
+    case '\n' =>
+      LineFeed // drop \r from \r\n
+    case _ =>
+      Print
+  }
+  val LineFeed: AnsiStateMachine = AnsiStateMachine(_ => LineFeed)
+  val Print: AnsiStateMachine = AnsiStateMachine(_ => Print)
+  val Discard: AnsiStateMachine = AnsiStateMachine(_ => Discard)
+  val AnsiEscape: AnsiStateMachine = AnsiStateMachine {
+    case '[' =>
+      AnsiNumericValue
+    case _ =>
+      Print
+  }
+  val AnsiNumericValue: AnsiStateMachine = AnsiStateMachine {
+    case '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' =>
+      AnsiValue
+    case _ =>
+      Print
+  }
+  val AnsiValue: AnsiStateMachine = AnsiStateMachine {
+    case '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' =>
+      AnsiValue
+    case ';' =>
+      AnsiNumericValue
+    case '@' | 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' |
+        'L' | 'M' | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' |
+        'X' | 'Y' | 'Z' | '[' | '\\' | ']' | '^' | '_' | '`' | 'a' | 'b' | 'c' |
+        'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' | 'l' | 'm' | 'n' | 'o' |
+        'p' | 'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x' | 'y' | 'z' | '{' |
+        '|' | '}' | '~' =>
+      Discard // end of ANSI escape
+    case _ =>
+      Print
+  }
+}

--- a/moped/src/main/scala/moped/internal/reporters/NoColorOutputStream.scala
+++ b/moped/src/main/scala/moped/internal/reporters/NoColorOutputStream.scala
@@ -1,0 +1,37 @@
+package moped.internal.reporters
+
+import java.io.OutputStream
+
+import scala.collection.mutable.ArrayBuffer
+
+class NoColorOutputStream(underlying: OutputStream) extends OutputStream() {
+
+  private val stack = ArrayBuffer.empty[Int]
+  private var state = AnsiStateMachine.Start
+
+  override def write(ch: Int): Unit =
+    synchronized {
+      state.apply(ch) match {
+        case AnsiStateMachine.Print =>
+          stack.foreach { i =>
+            underlying.write(i)
+          }
+          underlying.write(ch)
+          resetState()
+        case AnsiStateMachine.Discard =>
+          resetState()
+        case AnsiStateMachine.LineFeed =>
+          flush()
+          resetState()
+        case other =>
+          stack += ch
+          state = other
+      }
+    }
+
+  private def resetState(): Unit = {
+    stack.clear()
+    state = AnsiStateMachine.Start
+  }
+
+}

--- a/moped/src/main/scala/moped/internal/reporters/NoColorPrintStream.scala
+++ b/moped/src/main/scala/moped/internal/reporters/NoColorPrintStream.scala
@@ -1,0 +1,11 @@
+// This file contains adapted source code from tut, see NOTICE.md for LICENSE.
+// Original source: https://github.com/tpolecat/tut/blob/e692c74afe7cb9f144f464b97f100c11367c7dfa/modules/core/src/main/scala/tut/AnsiFilterStream.scala
+package moped.internal.reporters
+
+import java.io.OutputStream
+import java.io.PrintStream
+
+class NoColorPrintStream(underlying: PrintStream)
+    extends PrintStream(new NoColorOutputStream(underlying)) {
+  def this(out: OutputStream) = this(new PrintStream(out))
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.3
+sbt.version=1.5.2

--- a/tests/src/test/scala/tests/internal/reporters/NoColorOutputStreamSuite.scala
+++ b/tests/src/test/scala/tests/internal/reporters/NoColorOutputStreamSuite.scala
@@ -1,0 +1,62 @@
+package tests.internal.reporters
+
+import java.io.ByteArrayOutputStream
+
+import fansi.Bold
+import fansi.Color
+import fansi.Str
+import moped.cli.Application
+import moped.internal.reporters.NoColorPrintStream
+import moped.testkit.MopedSuite
+import munit.TestOptions
+
+object NoColorOutputStreamSuite {
+  val app: Application =
+    Application.simple("noColor") { app =>
+      app.info("hello")
+      app.out.println(Color.Blue("hello"))
+      app.err.println(Color.Green("hello"))
+      0
+    }
+}
+
+class NoColorOutputStreamSuite
+    extends MopedSuite(NoColorOutputStreamSuite.app) {
+  def checkNoColor(name: TestOptions, original: Str)(implicit
+      loc: munit.Location
+  ): Unit = {
+    test(name) {
+      val baos = new ByteArrayOutputStream
+      val ps = new NoColorPrintStream(baos)
+      ps.print(original)
+      ps.flush()
+      val obtained = baos.toString()
+      assertEquals(obtained, expected = original.plainText)
+    }
+  }
+
+  checkNoColor("basic", Color.Blue("info: ") ++ "hello")
+
+  checkNoColor("layered", Bold.On(Color.Blue("info: ")) ++ "hello")
+
+  test("NO_COLOR=true") {
+    runSuccessfully(
+      List(),
+      app()
+        .withEnv(app().env.withEnvironmentVariables(Map("NO_COLOR" -> "true")))
+    )
+    assertEquals(app.capturedRawOutput, "info: hello\nhello\nhello\n")
+  }
+
+  test("default") {
+    runSuccessfully(List())
+    assertEquals(
+      app.capturedRawOutput,
+      List(
+        Color.LightBlue("info: ") ++ "hello\n",
+        Color.Blue("hello") ++ "\n",
+        Color.Green("hello") ++ "\n"
+      ).mkString
+    )
+  }
+}


### PR DESCRIPTION
Previously, every moped application had to implement custom logic to
respect `NO_COLOR=true`. Now, this setting is automatically implemented
by replacing the provided print streams with a new `NoColorPrintStream`
that strips out ansi escape codes.